### PR TITLE
fix: fix bugs and improve robustness in upgrade.sh

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,27 +1,29 @@
 #!/usr/bin/env bash
 
 set -o errexit  # Used to exit upon error, avoiding cascading errors
+set -o nounset  # Treat unset variables as an error
 set -o pipefail # Unveils hidden failures
 # set -o xtrace   # Print commands and their arguments as they are executed.
 
-application="${1}"
-user="${2}"
+application="${1:-}"
+user="${2:-}"
 
 function help() {
     echo """
     Usage: ${0} <application>
 
-    Available applciations are: $(find applications -mindepth 1 -maxdepth 1 -type d -printf '%f ')
+    Available applications are: $(find applications -mindepth 1 -maxdepth 1 -type d -printf '%f ')
     """
     exit 1
 }
 
 [[ -z "${application}" ]] && help || echo "Application: ${application}"
-[[ -z "${user}" ]] && user="${application}"; echo "User: ${user}"
+[[ -z "${user}" ]] && user="${application}"
+echo "User: ${user}"
 
 [[ ! -d "applications/${application}" ]] && help
 
-if [ ! -d "/mnt/data/${applicaiton}" ];
+if [ ! -d "/mnt/data/${application}" ];
 then
     echo "No 'home' directory"
 fi


### PR DESCRIPTION
- Fix typo: ${applicaiton} -> ${application} on directory check
- Fix typo: "applciations" -> "applications" in help text
- Fix logic bug: group user assignment and echo so echo only runs when the condition is met
- Add set -o nounset to catch undefined variable errors early