### PR TITLE
Expand README with project overview, structure, and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,42 @@
-Home Lab
-========
+# Home Lab
 
-The purpose of this repository is to keep track of my current implementation of my personal home lab and give anyone who is interested in starting a base to work from.
+This repository is the source of truth for a personal homelab that is operated with **Infrastructure as Code** and **GitOps**.
 
+## Purpose
+
+The project has two goals:
+
+1. Keep infrastructure and application state reproducible and reviewable in Git.
+2. Serve as a practical reference for building and operating a small multi-cluster homelab on Oracle Cloud Infrastructure (OCI) and local/on-prem resources.
+
+In practice, this means:
+- Infrastructure is provisioned with Terraform (`infrastructure/`).
+- Kubernetes apps are managed through Argo CD inventories (`clusters/<cluster>/apps.yaml`).
+- App configuration lives in `applications/` and generated manifests are committed under `clusters/<cluster>/rendered/`.
+
+## Current State (as represented in this repo)
+
+- **Clusters**
+  - `clusters/oci`: primary cloud cluster inventory and rendered outputs.
+  - `clusters/trinity`: secondary cluster inventory and rendered outputs.
+- **GitOps model**
+  - Per-cluster app inventories define Helm and rendered applications.
+  - Argo CD bootstrap patterns and root app definitions are included in-cluster folders and Terraform.
+- **Infrastructure**
+  - OCI-focused Terraform for networking, compute, Kubernetes bootstrap, and supporting services.
+  - Cloudflare DNS/Tunnel Terraform in `infrastructure/cloudflare/`.
+- **Operations**
+  - Utility scripts under `scripts/` for maintenance and backups.
+  - Legacy Kubernetes-era Docker manifests kept for reference in `docker-scripts/`.
+
+## What this repository is not
+
+- It is not a polished starter template with one-click setup.
+- It is not a guarantee that every legacy manifest is still actively deployed.
+- It does not store secrets in Git; sensitive values are expected to be injected via variables/secrets tooling.
+
+## Suggested reading
+
+- `docs/gitops.md` for the cluster GitOps flow and Argo CD bootstrap pattern.
+- `infrastructure/cloudflare/README.md` for Cloudflare-specific Terraform usage.
+- `src/go/ci/README.md` for CI tooling used in this repository.


### PR DESCRIPTION
### Motivation
- Provide a clear project-level description that establishes this repository as the source of truth for a personal homelab managed with `Infrastructure as Code` and `GitOps`.
- Explain the repository goals of keeping infra and app state reproducible in Git and serving as a practical reference for a multi-cluster homelab on OCI and local resources.
- Clarify the layout and responsibilities of top-level folders so contributors can find Terraform, cluster inventories, and application manifests quickly.

### Description
- Replace the short header with an expanded `Purpose` section that states the two primary goals of the project and the GitOps/IaC intent.
- Add a `Current State` section that documents cluster inventories under `clusters/`, app configuration under `applications/`, and rendered manifests under `clusters/<cluster>/rendered/`.
- Document the `GitOps model` and the fact that infrastructure is provisioned with Terraform under `infrastructure/`, including Cloudflare DNS/Tunnel config in `infrastructure/cloudflare/`.
- Add `Operations`, `What this repository is not`, and `Suggested reading` sections to surface helpful scripts, caveats about secrets and polish, and pointers to `docs/gitops.md`, `infrastructure/cloudflare/README.md`, and `src/go/ci/README.md`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0a00d8c4832b8a9db8de0372a3bb)