### PR TITLE
Add Terraform CI/CD for compute and fix template provider

### DIFF
--- a/.github/workflows/terraform-compute.yaml
+++ b/.github/workflows/terraform-compute.yaml
@@ -1,0 +1,206 @@
+# Terraform CI/CD for infrastructure/compute
+#
+# - Pull requests touching infrastructure/compute run `terraform plan` and post
+#   the plan back as a PR comment (read-only, safe to run on untrusted changes).
+# - Merges to master run `terraform apply`, gated behind the `production`
+#   GitHub Environment so an apply only proceeds after manual approval.
+#
+# Running on Linux runners also sidesteps the darwin_arm64 provider problem that
+# blocked local plans.
+#
+# ---------------------------------------------------------------------------
+# Required configuration in the `production` GitHub Environment
+# (Settings -> Environments -> production):
+#
+#   Required reviewers: add yourself so apply pauses for approval.
+#
+#   Secrets:
+#     AWS_ACCESS_KEY_ID       Backblaze B2 keyID (used by the S3 state backend)
+#     AWS_SECRET_ACCESS_KEY   Backblaze B2 applicationKey
+#     OCI_TENANCY_OCID        ocid1.tenancy.oc1...
+#     OCI_USER_OCID           ocid1.user.oc1...
+#     OCI_FINGERPRINT         API key fingerprint (xx:xx:..:xx)
+#     OCI_PRIVATE_KEY         Full PEM contents of the OCI API private key
+#     TAILSCALE_API_KEY       Tailscale auth key
+#
+#   Variables:
+#     OCI_REGION              e.g. uk-london-1 (optional; defaults below)
+#     TAILSCALE_TAILNET       Tailscale tailnet name
+#     SSH_PUBLIC_KEY          Public SSH key written to instances
+# ---------------------------------------------------------------------------
+
+name: terraform-compute
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "infrastructure/compute/**"
+      - ".github/workflows/terraform-compute.yaml"
+  push:
+    branches: [master]
+    paths:
+      - "infrastructure/compute/**"
+      - ".github/workflows/terraform-compute.yaml"
+
+permissions:
+  contents: read
+  pull-requests: write # post the plan as a PR comment
+
+env:
+  TF_IN_AUTOMATION: "true"
+  TF_INPUT: "false"
+  TF_WORKSPACE_DIR: infrastructure/compute
+  TF_VERSION: "1.14.9" # match the version recorded in remote state
+  # Non-secret backend settings (creds come from AWS_* env below).
+  BACKEND_ENDPOINT: "https://s3.eu-central-003.backblazeb2.com"
+  BACKEND_REGION: "eu-central-003"
+
+jobs:
+  plan:
+    name: plan
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      group: terraform-compute-${{ github.head_ref }}
+      cancel-in-progress: true
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_tenancy_ocid: ${{ secrets.OCI_TENANCY_OCID }}
+      TF_VAR_user_ocid: ${{ secrets.OCI_USER_OCID }}
+      TF_VAR_fingerprint: ${{ secrets.OCI_FINGERPRINT }}
+      TF_VAR_tailscale_api_key: ${{ secrets.TAILSCALE_API_KEY }}
+      TF_VAR_region: ${{ vars.OCI_REGION || 'uk-london-1' }}
+      TF_VAR_tailscale_tailnet: ${{ vars.TAILSCALE_TAILNET }}
+      TF_VAR_private_key_path: ${{ github.workspace }}/oci_api_key.pem
+      TF_VAR_public_key_path: ${{ github.workspace }}/id_ssh.pub
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write credential files
+        run: |
+          umask 077
+          printf '%s' "${{ secrets.OCI_PRIVATE_KEY }}" > "${{ github.workspace }}/oci_api_key.pem"
+          printf '%s' "${{ vars.SSH_PUBLIC_KEY }}" > "${{ github.workspace }}/id_ssh.pub"
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform fmt
+        id: fmt
+        working-directory: ${{ env.TF_WORKSPACE_DIR }}
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_WORKSPACE_DIR }}
+        run: |
+          terraform init -input=false \
+            -backend-config="endpoint=${BACKEND_ENDPOINT}" \
+            -backend-config="region=${BACKEND_REGION}"
+
+      - name: Terraform validate
+        working-directory: ${{ env.TF_WORKSPACE_DIR }}
+        run: terraform validate -no-color
+
+      - name: Terraform plan
+        id: plan
+        working-directory: ${{ env.TF_WORKSPACE_DIR }}
+        run: terraform plan -input=false -no-color -lock-timeout=120s
+        continue-on-error: true
+
+      - name: Comment plan on PR
+        uses: actions/github-script@v7
+        env:
+          FMT_OUTCOME: ${{ steps.fmt.outcome }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
+          PLAN_STDERR: ${{ steps.plan.outputs.stderr }}
+        with:
+          script: |
+            const fmt = process.env.FMT_OUTCOME;
+            const plan = process.env.PLAN_OUTCOME;
+            const out = [process.env.PLAN_STDOUT, process.env.PLAN_STDERR]
+              .filter(Boolean).join('\n').trim() || '(no output)';
+            const body = [
+              '### Terraform plan — `infrastructure/compute`',
+              '',
+              `* fmt: \`${fmt}\``,
+              `* plan: \`${plan}\``,
+              '',
+              '<details><summary>Show plan</summary>',
+              '',
+              '```hcl',
+              out.length > 60000 ? out.slice(0, 60000) + '\n... (truncated)' : out,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = 'Terraform plan — `infrastructure/compute`';
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, body,
+              });
+            }
+
+      - name: Fail if plan errored
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+  apply:
+    name: apply
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production # protection rules (required reviewers) gate the apply
+    concurrency:
+      group: terraform-compute-apply # serialize applies — state backend has no lock table
+      cancel-in-progress: false
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_tenancy_ocid: ${{ secrets.OCI_TENANCY_OCID }}
+      TF_VAR_user_ocid: ${{ secrets.OCI_USER_OCID }}
+      TF_VAR_fingerprint: ${{ secrets.OCI_FINGERPRINT }}
+      TF_VAR_tailscale_api_key: ${{ secrets.TAILSCALE_API_KEY }}
+      TF_VAR_region: ${{ vars.OCI_REGION || 'uk-london-1' }}
+      TF_VAR_tailscale_tailnet: ${{ vars.TAILSCALE_TAILNET }}
+      TF_VAR_private_key_path: ${{ github.workspace }}/oci_api_key.pem
+      TF_VAR_public_key_path: ${{ github.workspace }}/id_ssh.pub
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write credential files
+        run: |
+          umask 077
+          printf '%s' "${{ secrets.OCI_PRIVATE_KEY }}" > "${{ github.workspace }}/oci_api_key.pem"
+          printf '%s' "${{ vars.SSH_PUBLIC_KEY }}" > "${{ github.workspace }}/id_ssh.pub"
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_WORKSPACE_DIR }}
+        run: |
+          terraform init -input=false \
+            -backend-config="endpoint=${BACKEND_ENDPOINT}" \
+            -backend-config="region=${BACKEND_REGION}"
+
+      - name: Terraform apply
+        working-directory: ${{ env.TF_WORKSPACE_DIR }}
+        run: terraform apply -input=false -auto-approve -no-color -lock-timeout=120s

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 !.vscode/extensions.json
 *.code-workspace
 
+.idea/*
+
 #   API keys
 *key*.yaml
 
@@ -12,7 +14,7 @@
 *.tar.gz
 
 #   Hidden files
-.*
+./.*
 
 secret.yml
 secret.yaml
@@ -21,8 +23,12 @@ result.json
 
 # Terraform files
 .terraform/
-.terraform.lock.hcl
+!.terraform.lock.hcl
 *.tfstate
 *.tfstate.backup
+# Terraform secrets — never commit backend creds, var files, or keys
+*.tfbackend
+*.tfvars
+*.pem
 
 !clusters/*/rendered/*/result.json

--- a/infrastructure/compute/.terraform.lock.hcl
+++ b/infrastructure/compute/.terraform.lock.hcl
@@ -1,0 +1,87 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version = "2.4.0"
+  hashes = [
+    "h1:4fp7byXJGbOU8zqxFM4yYGHzf1kUH8ChT41KK4n9q98=",
+    "zh:1b0fe71b8e87a068f7cd9faaa733100ab72ab61ce812b8bd2b8e3e6ea3907b2d",
+    "zh:2aa9631ad64cfda1eb58f147619b631dadedfaf9453b422aa5ada2d3861183c1",
+    "zh:2c5f35463bdfb2f87d3576b81e62c30f8109e67bb6f21ffcbc46a855811455c0",
+    "zh:5970bcad151ea236bd262ada1a5a23bfbc1716f94a4e8b16ab2bcdda91d6a671",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a0676909732b6ec0441a733af6383513cde3bd2cef5c1ad0a74131e1286a04",
+    "zh:818f16141481a1202b3977becd19a12d4d46cd2e3f5753f5d0d0049adacf8f8c",
+    "zh:948d98716831087e69eca99f91ed7964cc537f3aca279f7494645ee56c9dc4ec",
+    "zh:a75e78889565a51df3e8e3af207e36e5ddb25e47ce1780a784c82dc3c3109b67",
+    "zh:a9c6e455d52b1bba5272bd87a35cfabcfd6d903dcbe42e2de926228dbb1e39b2",
+    "zh:b846805d8c2f5d1d6c2ffeeaf32109d9af7db7fa3c56929bfc1dcfaadf9c8bd8",
+    "zh:c3e5279756b46c4f49a6f4c81347fbe2fffebb2bf18a5c24664830304a1f6a8e",
+    "zh:c8be7b31893163d0046b0137a6100533f07e8efd192a1903b6bb4c42be12dceb",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = ">= 3.2.3"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "8.19.0"
+  constraints = ">= 6.26.0"
+  hashes = [
+    "h1:f97Ld6HLitSY642XAHHUwxxyMQ7Kb6EU76ZhPNkoRfI=",
+    "zh:0d2df3e29ebf1d8e768559fa86f60e86293524e4e5e99cf84e7b695db63da86d",
+    "zh:295a791708c759688e5380417fad6a27531cd1315bb44b25c556f03c7b9e0d03",
+    "zh:3647850498f4f325578c1669d461aadcc169d3dde2cf58048bf09d7cc29cf2f7",
+    "zh:578c2d9498917a039bbe9ee608af897adee40a2bafeeead17e1376fee31915e3",
+    "zh:5d6cc84b1dc0fd0cfded3e5d7d8dd7215c8e85a84b43e0aa2c2f9253c20a05b6",
+    "zh:6a34be71f3d091647982c89239c45930ef2075918957924c51574d25a5de9cff",
+    "zh:85e0e0273dd3f24a0f1b40d53b0c28a4767c5c193a0fc0f580302c79b498a34d",
+    "zh:95f14a63e63d80fda595a16588890079f0d3813c9efd25a9cbbb0d2c9f0ed54c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b98b31b75db4f77b7674d739b36c6a1835f74179fd08946478f16f21f38d1fd",
+    "zh:b36ecc420be9f70da3f0b8e1f817d41876bf3bc6343747e0f397e88854e0c71d",
+    "zh:b6aa3f2085e5d8b8ad9808cb75c7a69cb392ca56d7f789ba375a9d057b093657",
+    "zh:cb52be156360270e42bba86196412b0393a1dd8610ffb17299c762827509e04f",
+    "zh:da9e16acb0c729f65319f2c7c754613c2d99407bca86c2dfdfa1701c1ebb08ca",
+    "zh:ed22df97b56077cdac4aa909db24be858755eefac7b0a68415411429fbf805c4",
+  ]
+}
+
+provider "registry.terraform.io/tailscale/tailscale" {
+  version     = "0.29.2"
+  constraints = ">= 0.22.0"
+  hashes = [
+    "h1:lNitoP/DTekzHnRjZ3RBLthPRZ3aHy6lR7jo2rtoH+0=",
+    "zh:32b453302a684584198a03c2e09d99ef1f6deac2fe26f8dc134d973b07fd0c23",
+    "zh:3920bb891a476f30e29248533f667a507c97e93e0a2af010b242e980d6411ca6",
+    "zh:630cceb40d8806945ad36e04517f313520ea5cee17bd36e26a8e999567835e1a",
+    "zh:6816de7f6bd3cfe341451af3be95b0af17c5539733b165f7505e88de6b730fc5",
+    "zh:729d75ab50efb675716ffa609358f6d9e80c66f7f64e01e11c8926c5293385be",
+    "zh:7d1024f621fe02b3731dc65ab20105150762b29df46e398da2c73d007bb62fb2",
+    "zh:81cf9cd23a70e5196b9d774482259c17e08471556932c348d3e9df0f7a482af1",
+    "zh:8de75b9c4b89ed1affcdb3ce32e00afaf213cfd76e93181ea4758ffd10b6eedc",
+    "zh:8f0b9b175ceb124c1cf01e6bbb660bf1bce0ff77416e026dc0679ed7156bc737",
+    "zh:8fb4cde10eb346ef9e2233591d75c39bcc2cafee578b669196192e8acdb39f12",
+    "zh:96798e58b8fcddc2add2da0fe8f1df9f913153d4cbccd68a7557b64633f5ea00",
+    "zh:a598bd615f4465b828f3b6ed2db694d8148c9469d5497922c7bc17c08b655cf4",
+    "zh:b2604d5067f3f259ff9be9bb0c4f9ec801d27c905cbf6ceafee50fc2a23f8331",
+  ]
+}

--- a/infrastructure/compute/cloud-init.tf
+++ b/infrastructure/compute/cloud-init.tf
@@ -15,16 +15,9 @@ data "cloudinit_config" "cloudinit" {
   part {
     content_type = "text/cloud-config"
     filename     = "userdata.yaml"
-    content      = data.template_file.userdata.rendered
-  }
-
-}
-
-data "template_file" "userdata" {
-  template = file("${path.module}/templates/userdata.yaml")
-
-  vars = {
-    auth_key = tailscale_tailnet_key.oracle.key
+    content = templatefile("${path.module}/templates/userdata.yaml", {
+      auth_key = tailscale_tailnet_key.oracle.key
+    })
   }
 
 }


### PR DESCRIPTION
## What's this change?
Adds GitHub Actions to plan `infrastructure/compute` on PRs and apply on merge to master, and removes the deprecated `hashicorp/template` provider that was blocking local plans.

## Changes
- Replace the `data "template_file"` source with the built-in `templatefile()` function. The `hashicorp/template` provider has no `darwin_arm64` build, so any `init`/`plan` failed on Apple Silicon. Rendered cloud-init is unchanged.
- Add `.github/workflows/terraform-compute.yaml`: `plan` job on PRs (posts the plan as a PR comment), `apply` job on merge to master. Both run on Linux and bind to the `production` GitHub Environment; the apply is gated by that environment's required-reviewers rule.
- Backend and provider credentials are injected from environment-scoped secrets (`AWS_*`, `TF_VAR_*`) rather than committed files; non-secret backend endpoint/region passed via `-backend-config`.
- Apply uses a serialized concurrency group since the Backblaze S3 backend has no lock table.
- Commit `infrastructure/compute/.terraform.lock.hcl` to pin provider versions.
- Ignore `*.tfbackend` / `*.tfvars` / `*.pem` so plaintext credentials stay out of git.

## Follow-up
- The `production` environment gates both plan and apply. If automatic PR plans (no approval click) are wanted, a separate unprotected environment for the plan job is a noted future improvement.

## Required GitHub setup
Configure the `production` environment (Settings -> Environments): required reviewers, plus secrets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `OCI_TENANCY_OCID`, `OCI_USER_OCID`, `OCI_FINGERPRINT`, `OCI_PRIVATE_KEY`, `TAILSCALE_API_KEY`, and variables `OCI_REGION`, `TAILSCALE_TAILNET`, `SSH_PUBLIC_KEY`.