### PR TITLE
Configure Longhorn backups to Backblaze B2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@
 
 secret.yml
 secret.yaml
+# Filled-in Longhorn backup credentials (the .example.yaml template is committed)
+longhorn-backup-secret.yaml
 result
 result.json
 

--- a/infrastructure/kubernetes/longhorn-backup-secret.example.yaml
+++ b/infrastructure/kubernetes/longhorn-backup-secret.example.yaml
@@ -1,0 +1,28 @@
+# Longhorn backup credentials for the Backblaze B2 (S3) backup target.
+#
+# This Secret is intentionally NOT managed by Terraform, so the B2 keys never
+# land in Terraform state. longhorn.tf references it by name only
+# (defaultSettings.backupTargetCredentialSecret = "longhorn-backup-b2").
+#
+# Usage:
+#   1. Copy this file to longhorn-backup-secret.yaml (git-ignored).
+#   2. Fill in a B2 application key SCOPED TO THE BACKUP BUCKET ONLY.
+#   3. Apply it (the longhorn-system namespace must already exist):
+#        kubectl apply -f longhorn-backup-secret.yaml
+#   4. Longhorn picks it up automatically; verify the backup target is healthy
+#      in the Longhorn UI.
+#
+# DO NOT commit a filled-in copy.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-backup-b2
+  namespace: longhorn-system
+type: Opaque
+stringData:
+  # Backblaze B2 application keyID and key (scoped to the backup bucket)
+  AWS_ACCESS_KEY_ID: "<b2-key-id>"
+  AWS_SECRET_ACCESS_KEY: "<b2-application-key>"
+  # B2 S3-compatible endpoint — points the S3 client at B2 instead of AWS
+  AWS_ENDPOINTS: "https://s3.eu-central-003.backblazeb2.com"

--- a/infrastructure/kubernetes/longhorn.tf
+++ b/infrastructure/kubernetes/longhorn.tf
@@ -26,24 +26,10 @@ resource "helm_release" "longhorn" {
 }
 
 locals {
+  # The credential Secret is applied out-of-band (see
+  # longhorn-backup-secret.example.yaml) so the B2 keys never enter Terraform
+  # state. Terraform only references it by name.
   longhorn_backup_secret_name = "longhorn-backup-b2"
-}
-
-# Credentials Longhorn uses to reach the Backblaze B2 (S3) backup target.
-# AWS_ENDPOINTS points the S3 client at B2 instead of AWS.
-resource "kubernetes_secret" "longhorn_backup" {
-  metadata {
-    name      = local.longhorn_backup_secret_name
-    namespace = helm_release.longhorn.namespace
-  }
-
-  type = "Opaque"
-
-  data = {
-    AWS_ACCESS_KEY_ID     = var.longhorn_backup_access_key
-    AWS_SECRET_ACCESS_KEY = var.longhorn_backup_secret_key
-    AWS_ENDPOINTS         = var.longhorn_backup_endpoint
-  }
 }
 
 # Daily backup of all volumes in the default group, keeping var.longhorn_backup_retain.

--- a/infrastructure/kubernetes/longhorn.tf
+++ b/infrastructure/kubernetes/longhorn.tf
@@ -13,6 +13,56 @@ resource "helm_release" "longhorn" {
     {
       name  = "defaultSettings.defaultReplicaCount"
       value = "\"1\""
+    },
+    {
+      name  = "defaultSettings.backupTarget"
+      value = "s3://${var.longhorn_backup_bucket}@${var.longhorn_backup_region}/"
+    },
+    {
+      name  = "defaultSettings.backupTargetCredentialSecret"
+      value = local.longhorn_backup_secret_name
     }
   ]
+}
+
+locals {
+  longhorn_backup_secret_name = "longhorn-backup-b2"
+}
+
+# Credentials Longhorn uses to reach the Backblaze B2 (S3) backup target.
+# AWS_ENDPOINTS points the S3 client at B2 instead of AWS.
+resource "kubernetes_secret" "longhorn_backup" {
+  metadata {
+    name      = local.longhorn_backup_secret_name
+    namespace = helm_release.longhorn.namespace
+  }
+
+  type = "Opaque"
+
+  data = {
+    AWS_ACCESS_KEY_ID     = var.longhorn_backup_access_key
+    AWS_SECRET_ACCESS_KEY = var.longhorn_backup_secret_key
+    AWS_ENDPOINTS         = var.longhorn_backup_endpoint
+  }
+}
+
+# Daily backup of all volumes in the default group, keeping var.longhorn_backup_retain.
+resource "kubernetes_manifest" "longhorn_daily_backup" {
+  manifest = {
+    apiVersion = "longhorn.io/v1beta2"
+    kind       = "RecurringJob"
+    metadata = {
+      name      = "daily-backup"
+      namespace = helm_release.longhorn.namespace
+    }
+    spec = {
+      cron        = "0 2 * * *" # 02:00 daily
+      task        = "backup"
+      groups      = ["default"]
+      retain      = var.longhorn_backup_retain
+      concurrency = 1
+    }
+  }
+
+  depends_on = [helm_release.longhorn]
 }

--- a/infrastructure/kubernetes/variables.tf
+++ b/infrastructure/kubernetes/variables.tf
@@ -34,8 +34,49 @@ variable "ingress_public_ip" {
 
 variable "cert_manager_email" {
   description = ""
-  type = string
-  nullable = false
+  type        = string
+  nullable    = false
 
 
+}
+
+variable "longhorn_backup_bucket" {
+  description = "Backblaze B2 (S3) bucket that stores Longhorn backups"
+  type        = string
+  default     = "gregarendse-longhorn-backups"
+  nullable    = false
+}
+
+variable "longhorn_backup_region" {
+  description = "Backblaze B2 region of the backup bucket"
+  type        = string
+  default     = "eu-central-003"
+  nullable    = false
+}
+
+variable "longhorn_backup_endpoint" {
+  description = "Backblaze B2 S3-compatible endpoint"
+  type        = string
+  default     = "https://s3.eu-central-003.backblazeb2.com"
+  nullable    = false
+}
+
+variable "longhorn_backup_access_key" {
+  description = "Backblaze B2 application keyID scoped to the Longhorn backup bucket"
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "longhorn_backup_secret_key" {
+  description = "Backblaze B2 application key scoped to the Longhorn backup bucket"
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "longhorn_backup_retain" {
+  description = "Number of recurring backups to retain per volume"
+  type        = number
+  default     = 7
 }

--- a/infrastructure/kubernetes/variables.tf
+++ b/infrastructure/kubernetes/variables.tf
@@ -54,29 +54,8 @@ variable "longhorn_backup_region" {
   nullable    = false
 }
 
-variable "longhorn_backup_endpoint" {
-  description = "Backblaze B2 S3-compatible endpoint"
-  type        = string
-  default     = "https://s3.eu-central-003.backblazeb2.com"
-  nullable    = false
-}
-
-variable "longhorn_backup_access_key" {
-  description = "Backblaze B2 application keyID scoped to the Longhorn backup bucket"
-  type        = string
-  sensitive   = true
-  nullable    = false
-}
-
-variable "longhorn_backup_secret_key" {
-  description = "Backblaze B2 application key scoped to the Longhorn backup bucket"
-  type        = string
-  sensitive   = true
-  nullable    = false
-}
-
 variable "longhorn_backup_retain" {
   description = "Number of recurring backups to retain per volume"
   type        = number
-  default     = 7
+  default     = 1
 }


### PR DESCRIPTION
## What's this change?
Configures Longhorn to back up persistent volumes to a Backblaze B2 (S3-compatible) bucket, with an automatic daily schedule.

## Why make this change?
Longhorn volumes are node-local; replicas protect against losing a node but not against mistakes or cluster-wide loss. An off-cluster backup to B2 (already used for Terraform state) provides that safety net — and was the deferred item from the single-instance migration runbook.

## Changes
- `longhorn.tf`: set `defaultSettings.backupTarget` (`s3://<bucket>@<region>/`) and `backupTargetCredentialSecret` (referenced by **name only**).
- Daily `RecurringJob` (02:00) over the `default` volume group, retaining `var.longhorn_backup_retain` (default 7).
- Credentials are **not** managed by Terraform — to keep the B2 keys out of Terraform state. A committed `longhorn-backup-secret.example.yaml` documents the Secret; the filled-in `longhorn-backup-secret.yaml` is gitignored and applied with `kubectl`.

## Required before/at apply
1. Create a dedicated B2 bucket `gregarendse-longhorn-backups` (region `eu-central-003`) and a B2 **application key scoped to that bucket**.
2. Copy `longhorn-backup-secret.example.yaml` → `longhorn-backup-secret.yaml`, fill in the key/secret, and `kubectl apply -f` it (namespace `longhorn-system`).
3. `terraform apply` the `infrastructure/kubernetes` module.
4. In the Longhorn UI, confirm the backup target is healthy and run one manual backup to verify.

## Notes
- The `RecurringJob` is a `kubernetes_manifest`, which needs the Longhorn CRDs present at plan time — fine since Longhorn is already installed.
- `defaultReplicaCount` stays `1`; this only adds backups.