### PR TITLE
fix(cloud-init): harden apt stability on K8s nodes

### DIFF
--- a/infrastructure/compute/templates/userdata.yaml
+++ b/infrastructure/compute/templates/userdata.yaml
@@ -2,7 +2,6 @@
 # The above header must generally appear on the first line of a cloud config
 # file, but all other lines that begin with a # are optional comments.
 
-
 packages:
   - apt-transport-https
   - jq
@@ -11,7 +10,50 @@ packages:
   - unattended-upgrades
   - update-notifier-common
 
+write_files:
+  # Prevent apt from hanging indefinitely on stalled mirror connections.
+  # Without this, apt's HTTP methods block forever on a dead socket, which
+  # is what caused the 20-day stuck apt-get process on May 30.
+  - path: /etc/apt/apt.conf.d/99-timeout
+    owner: root:root
+    permissions: '0644'
+    content: |
+      Acquire::http::Timeout "30";
+      Acquire::https::Timeout "30";
+      Acquire::Retries "3";
+
+  # Raise inotify watch limits. On K8s nodes, kubelet and containerd exhaust
+  # the default 8192 watches, causing apt to fail with "Too many open files".
+  # 524288 is the standard k8s node recommendation (~30 MB overhead at max).
+  - path: /etc/sysctl.d/99-inotify.conf
+    owner: root:root
+    permissions: '0644'
+    content: |
+      fs.inotify.max_user_watches=524288
+      fs.inotify.max_user_instances=512
+
+  # Kill apt-daily if it hangs, rather than blocking all manual apt calls.
+  - path: /etc/systemd/system/apt-daily.service.d/override.conf
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Service]
+      TimeoutStartSec=15min
+      TimeoutStopSec=60
+
+  - path: /etc/systemd/system/apt-daily-upgrade.service.d/override.conf
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Service]
+      TimeoutStartSec=30min
+      TimeoutStopSec=60
+
 runcmd:
+  # Apply all sysctl conf.d files, including 99-inotify.conf written above.
+  # write_files runs before runcmd so the file is already in place here.
+  - ['sysctl', '--system']
+
   # One-command install, from https://tailscale.com/download/
   - ['sh', '-c', 'curl -fsSL https://tailscale.com/install.sh | sh']
   # Set sysctl settings for IP forwarding (useful when configuring an exit node)
@@ -41,6 +83,9 @@ runcmd:
     # Update unattended-upgrades config to set reboot time
     sed -i "s|^//Unattended-Upgrade::Automatic-RebootTime.*$|Unattended-Upgrade::Automatic-RebootTime \"$REBOOT_TIME\";|" /etc/apt/apt.conf.d/50unattended-upgrades
 
+  # Reload systemd so the apt-daily timeout overrides are active before the
+  # service is enabled. Must come after write_files has placed the overrides.
+  - ['systemctl', 'daemon-reload']
 
   # Enable and start unattended-upgrades
   - ['systemctl', 'enable', '--now', 'unattended-upgrades']


### PR DESCRIPTION
Three issues diagnosed on ubuntu-5:

1. apt-get hung for 20 days (since May 30) due to a stalled HTTP connection to an apt mirror. apt has no default timeout, so the _apt/methods/http workers block indefinitely on a dead socket.

2. `apt update` failing with "Too many open files" — not a file descriptor issue but inotify watch exhaustion. kubelet and containerd consume the default 8192 watch slots before apt can register its own.

3. A stuck apt-daily run holds /var/lib/apt/lists/lock forever, blocking all manual apt invocations until the process is killed by hand.

Fixes:
- write_files: /etc/apt/apt.conf.d/99-timeout — 30s HTTP/HTTPS timeout with 3 retries, prevents indefinite blocking on dead mirrors
- write_files: /etc/sysctl.d/99-inotify.conf — raises max_user_watches to 524288 and max_user_instances to 512 (standard K8s node values)
- write_files: systemd overrides for apt-daily{,-upgrade}.service — TimeoutStartSec kills a hung run at 15/30 min rather than waiting forever
- runcmd: sysctl --system early in boot to activate inotify settings (write_files completes before runcmd, so the conf is already on disk)
- runcmd: systemctl daemon-reload before enabling unattended-upgrades so the timeout overrides are loaded before the service starts