### PR TITLE
gSetup monitoring stack 14465172909638970922

### DIFF
--- a/applications/loki/values.yaml
+++ b/applications/loki/values.yaml
@@ -4,22 +4,34 @@ loki:
     replication_factor: 1
   storage:
     type: s3
+    # Chart 6.27.0 (Loki 3.x) requires a bucketNames map. We only have a single
+    # OCI bucket, so point all three at it.
+    bucketNames:
+      chunks: homelab-loki-logs
+      ruler: homelab-loki-logs
+      admin: homelab-loki-logs
     s3:
-      # OCI Object Storage S3 compatibility
-      # Replace <namespace> and <region> with your OCI values
+      # OCI Object Storage S3 compatibility endpoint.
       endpoint: https://lrheyvqgbq67.compat.objectstorage.uk-london-1.oraclecloud.com
-      bucketnames: homelab-loki-logs
+      region: uk-london-1
       s3ForcePathStyle: true
-      access_key_id:
-        valueFrom:
-          secretKeyRef:
-            name: loki-s3-secret
-            key: access_key
-      secret_access_key:
-        valueFrom:
-          secretKeyRef:
-            name: loki-s3-secret
-            key: secret_key
+      # Credentials are injected as environment variables (see singleBinary's
+      # extraEnvFrom + extraArgs below) and expanded into the config at runtime,
+      # so they never land in the rendered ConfigMap. The env var names match the
+      # keys in the loki-s3-secret Secret (access_key / secret_key).
+      accessKeyId: ${access_key}
+      secretAccessKey: ${secret_key}
+
+  # Required for a real install. TSDB + v13 schema is the current default.
+  schemaConfig:
+    configs:
+      - from: 2024-04-01
+        store: tsdb
+        object_store: s3
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
 
   # Retention guardrails
   limits_config:
@@ -32,6 +44,12 @@ loki:
     retention_delete_delay: 2h
     retention_delete_worker_count: 150
 
+# Inject the OCI S3 credentials from the Secret as env vars and enable env
+# expansion in the Loki config. The loki-s3-secret Secret is created by Terraform
+# (infrastructure/kubernetes/loki.tf). See applications/loki/README.md.
+# NOTE: these must live under `singleBinary` (not `global`) because only the
+# per-component blocks are wired into the StatefulSet in this chart version.
+
 deploymentMode: SingleBinary
 
 singleBinary:
@@ -40,7 +58,28 @@ singleBinary:
     enabled: true
     storageClass: longhorn
     size: 5Gi
+  extraArgs:
+    - -config.expand-env=true
+  extraEnvFrom:
+    - secretRef:
+        name: loki-s3-secret
 
-# OCI S3 credentials are injected via the `loki-s3-secret` Secret.
-# That Secret is created by Terraform (infrastructure/kubernetes/loki.tf) from
-# credentials provisioned in infrastructure/storage. See applications/loki/README.md.
+# SingleBinary mode requires the SimpleScalable targets to be disabled, otherwise
+# the chart's validate.yaml fails ("more than zero replicas for both ... targets").
+write:
+  replicas: 0
+read:
+  replicas: 0
+backend:
+  replicas: 0
+
+# Trim the heavyweight optional components for a small single-binary homelab
+# install. chunksCache alone requests ~8Gi of memory by default.
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+lokiCanary:
+  enabled: false
+test:
+  enabled: false


### PR DESCRIPTION
The 6.27.0 chart (Loki 3.x) changed the storage config schema, causing a nil-pointer template error on loki.storage.bucketNames.chunks.

- Add storage.bucketNames map (chunks/ruler/admin -> single OCI bucket)
- Inject S3 credentials via singleBinary extraEnvFrom + -config.expand-env instead of the unsupported secretKeyRef blocks (keeps secrets out of the rendered ConfigMap)
- Add required schemaConfig (TSDB v13)
- Zero write/read/backend replicas for SingleBinary mode
- Disable chunksCache/resultsCache/lokiCanary/test for a small install

Validated with helm template against chart 6.27.0, kube 1.33.5.