### PR TITLE
ci: add helm + kubenix manifest validation

### DIFF
--- a/.github/workflows/validate-manifests.yaml
+++ b/.github/workflows/validate-manifests.yaml
@@ -1,0 +1,92 @@
+name: validate-manifests
+
+# Validates Kubernetes manifests on every pull request:
+#   * Helm: lints the shared server/ chart and renders every path-type Helm app
+#     from clusters/*/apps.yaml, then schema-checks the output with kubeconform.
+#   * Nix/kubenix: builds each applications/<app> that has a flake.nix and
+#     schema-checks the rendered manifests with kubeconform.
+#
+# These checks catch malformed templates, bad value overrides, and manifests
+# that don't match the Kubernetes API schema — failures that previously only
+# surfaced at deploy time.
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "server/**"
+      - "applications/**"
+      - "clusters/*/apps.yaml"
+      - "scripts/validate-helm.sh"
+      - "scripts/validate-manifests.sh"
+      - ".github/workflows/validate-manifests.yaml"
+
+concurrency:
+  group: validate-manifests-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  # Validate against the cluster's Kubernetes version (kubenix apps target 1.28).
+  KUBE_VERSION: "1.28.0"
+  KUBECONFORM_VERSION: "v0.7.0"
+  YQ_VERSION: "v4.44.6"
+
+jobs:
+  helm:
+    name: helm charts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - name: Install yq and kubeconform
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo curl -fsSL \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+          curl -fsSL \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+          yq --version
+          kubeconform -v
+
+      - name: Validate Helm apps
+        run: scripts/validate-helm.sh
+
+  kubenix:
+    name: kubenix manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install yq and kubeconform
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo curl -fsSL \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+          curl -fsSL \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+          yq --version
+          kubeconform -v
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+
+      # result.json files are gitignored, so build each kubenix app fresh
+      # before validating its rendered manifests.
+      - name: Validate kubenix manifests
+        run: scripts/validate-manifests.sh --build

--- a/scripts/README-validation.md
+++ b/scripts/README-validation.md
@@ -1,0 +1,56 @@
+# Manifest validation
+
+Two scripts validate the cluster's Kubernetes manifests so that schema and
+template errors are caught in CI instead of at deploy time. They run
+automatically on pull requests via `.github/workflows/validate-manifests.yaml`,
+and can also be run locally.
+
+## What gets checked
+
+| Script | Covers | How |
+|---|---|---|
+| `scripts/validate-helm.sh` | Every path-type Helm app in `clusters/*/apps.yaml` (the shared `server/` chart + per-app `values.yaml`) | `helm lint` + `helm template` piped through `kubeconform` |
+| `scripts/validate-manifests.sh` | Every kubenix app (`applications/<app>/flake.nix`) | `nix build` → normalise the rendered `result.json` → `kubeconform` |
+
+`kubeconform` validates each manifest against the Kubernetes API schema for the
+version in `KUBE_VERSION` (default `1.28.0`, matching the cluster). Custom
+resources are checked against the
+[CRDs-catalog](https://github.com/datreeio/CRDs-catalog); CRDs that aren't in
+the catalog are skipped (`-ignore-missing-schemas`) rather than failing.
+
+## Requirements
+
+- [`helm`](https://helm.sh/) (Helm script only)
+- [`yq`](https://github.com/mikefarah/yq) v4
+- [`kubeconform`](https://github.com/yannh/kubeconform)
+- [`nix`](https://nixos.org/) (only when building kubenix apps with `--build`)
+
+## Running locally
+
+```bash
+# Validate all Helm apps
+scripts/validate-helm.sh
+
+# Validate only specific Helm apps
+scripts/validate-helm.sh plex sonarr
+
+# Validate kubenix apps using their existing result.json
+scripts/validate-manifests.sh
+
+# Rebuild kubenix apps first (needed if result.json is missing — it's gitignored)
+scripts/validate-manifests.sh --build
+
+# Build + validate a single kubenix app
+scripts/validate-manifests.sh --build pihole
+```
+
+Override the target Kubernetes version with the `KUBE_VERSION` environment
+variable, e.g. `KUBE_VERSION=1.29.0 scripts/validate-helm.sh`.
+
+## Notes
+
+- `applications/*/result.json` is gitignored, so CI builds each kubenix app
+  fresh with `nix build` (the `--build` flag) before validating it.
+- `openclaw` has no committed `flake.nix`, so it is not auto-discovered by the
+  kubenix validator. Add a `flake.nix` (as the other kubenix apps have) to bring
+  it under validation.

--- a/scripts/validate-helm.sh
+++ b/scripts/validate-helm.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Validate the shared "server" Helm chart and every app that renders it.
+#
+# What it does:
+#   1. `helm lint` the shared server/ chart with each app's values.
+#   2. `helm template` each path-type Helm app declared in clusters/*/apps.yaml
+#      and pipe the rendered manifests through kubeconform for schema validation.
+#
+# This catches the classes of error that previously only surfaced at deploy
+# time: malformed templates, bad value overrides, and manifests that don't
+# match the Kubernetes API schema.
+#
+# Requirements: helm, yq, kubeconform (see scripts/README-validation.md).
+#
+# Usage:
+#   scripts/validate-helm.sh                 # validate all helm apps
+#   scripts/validate-helm.sh plex sonarr     # validate only the named apps
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Resolve repo root regardless of where the script is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Kubernetes version to validate manifests against. Keep in sync with the
+# cluster (kubenix apps target 1.28 — see AGENTS.md).
+KUBE_VERSION="${KUBE_VERSION:-1.28.0}"
+
+# Schema locations for kubeconform. The default location covers built-in
+# Kubernetes APIs; the CRDs-catalog covers common custom resources (VPA,
+# cert-manager, Traefik, Argo CD, ...). Unknown CRDs are skipped rather than
+# failing the build.
+CRD_SCHEMAS="https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+# --- dependency checks ------------------------------------------------------
+
+for tool in helm yq kubeconform; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "ERROR: required tool '${tool}' is not installed or not on PATH." >&2
+    exit 127
+  fi
+done
+
+# --- discover apps ----------------------------------------------------------
+
+# Emits TSV rows: name<TAB>namespace<TAB>chartPath<TAB>valuesFile for every
+# path-type Helm app across all cluster inventories.
+discover_apps() {
+  local inventory
+  for inventory in clusters/*/apps.yaml; do
+    [[ -e "${inventory}" ]] || continue
+    yq -r '
+      .apps[]
+      | select(.type == "helm" and .helm.kind == "path")
+      | [.name, (.namespace // .name), .helm.path, (.helm.valueFiles[0] // "")]
+      | @tsv
+    ' "${inventory}"
+  done
+}
+
+# Optional positional args restrict validation to the named apps.
+declare -a ONLY_APPS=("$@")
+
+app_selected() {
+  local name="$1"
+  [[ ${#ONLY_APPS[@]} -eq 0 ]] && return 0
+  local a
+  for a in "${ONLY_APPS[@]}"; do
+    [[ "${a}" == "${name}" ]] && return 0
+  done
+  return 1
+}
+
+# --- validation -------------------------------------------------------------
+
+failures=0
+checked=0
+
+while IFS=$'\t' read -r name namespace chart values; do
+  [[ -z "${name}" ]] && continue
+  app_selected "${name}" || continue
+
+  if [[ ! -f "${values}" ]]; then
+    echo "ERROR: ${name}: values file '${values}' not found" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "==> ${name} (chart=${chart}, namespace=${namespace})"
+
+  # 1. helm lint — catches template/values problems early with clear messages.
+  if ! helm lint "${chart}" --values "${values}" >/tmp/helm-lint.out 2>&1; then
+    echo "    helm lint FAILED:" >&2
+    sed 's/^/      /' /tmp/helm-lint.out >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  # 2. helm template + kubeconform — catches schema violations.
+  if ! helm template "${name}" "${chart}" \
+        --namespace "${namespace}" \
+        --values "${values}" >/tmp/helm-template.out 2>/tmp/helm-template.err; then
+    echo "    helm template FAILED:" >&2
+    sed 's/^/      /' /tmp/helm-template.err >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if ! kubeconform \
+        -strict \
+        -summary \
+        -kubernetes-version "${KUBE_VERSION}" \
+        -schema-location default \
+        -schema-location "${CRD_SCHEMAS}" \
+        -ignore-missing-schemas \
+        /tmp/helm-template.out; then
+    echo "    kubeconform FAILED for ${name}" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  checked=$((checked + 1))
+done < <(discover_apps)
+
+echo
+if [[ ${failures} -gt 0 ]]; then
+  echo "Helm validation FAILED: ${failures} app(s) with errors (${checked} passed)." >&2
+  exit 1
+fi
+
+echo "Helm validation passed: ${checked} app(s) validated."

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Validate Nix/kubenix-managed Kubernetes manifests against the API schema.
+#
+# Each kubenix app under applications/<app>/ builds to a result.json file that
+# contains a Kubernetes List (or a single object). This script:
+#   1. Optionally (re)builds each app with `nix build` when --build is passed
+#      (or when the result.json is missing).
+#   2. Normalises the List into individual manifests.
+#   3. Runs kubeconform to confirm every manifest matches the API schema.
+#
+# This catches schema mistakes in the .nix definitions before they reach Argo
+# CD / the cluster.
+#
+# Requirements: yq, kubeconform (and nix when using --build).
+#
+# Usage:
+#   scripts/validate-manifests.sh                  # validate existing result.json files
+#   scripts/validate-manifests.sh --build          # nix build every app first
+#   scripts/validate-manifests.sh pihole ollama    # validate only the named apps
+#   scripts/validate-manifests.sh --build pihole   # build + validate one app
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+KUBE_VERSION="${KUBE_VERSION:-1.28.0}"
+CRD_SCHEMAS="https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+# --- argument parsing -------------------------------------------------------
+
+BUILD=0
+declare -a ONLY_APPS=()
+for arg in "$@"; do
+  case "${arg}" in
+    --build) BUILD=1 ;;
+    -*) echo "ERROR: unknown flag '${arg}'" >&2; exit 2 ;;
+    *) ONLY_APPS+=("${arg}") ;;
+  esac
+done
+
+# --- dependency checks ------------------------------------------------------
+
+required_tools=(yq kubeconform)
+[[ ${BUILD} -eq 1 ]] && required_tools+=(nix)
+for tool in "${required_tools[@]}"; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "ERROR: required tool '${tool}' is not installed or not on PATH." >&2
+    exit 127
+  fi
+done
+
+# --- discover kubenix apps --------------------------------------------------
+
+# A kubenix app is an applications/<app>/ directory containing a flake.nix.
+discover_apps() {
+  local flake
+  for flake in applications/*/flake.nix; do
+    [[ -e "${flake}" ]] || continue
+    basename "$(dirname "${flake}")"
+  done
+}
+
+app_selected() {
+  local name="$1"
+  [[ ${#ONLY_APPS[@]} -eq 0 ]] && return 0
+  local a
+  for a in "${ONLY_APPS[@]}"; do
+    [[ "${a}" == "${name}" ]] && return 0
+  done
+  return 1
+}
+
+# --- validation -------------------------------------------------------------
+
+failures=0
+checked=0
+
+while read -r app; do
+  [[ -z "${app}" ]] && continue
+  app_selected "${app}" || continue
+
+  app_dir="applications/${app}"
+  result="${app_dir}/result.json"
+
+  if [[ ${BUILD} -eq 1 || ! -f "${result}" ]]; then
+    echo "==> ${app}: nix build"
+    rm -f "${result}"
+    if ! ( cd "${app_dir}" && nix build --out-link result.json ) >/tmp/nix-build.out 2>&1; then
+      echo "    nix build FAILED:" >&2
+      sed 's/^/      /' /tmp/nix-build.out >&2
+      failures=$((failures + 1))
+      continue
+    fi
+  fi
+
+  if [[ ! -f "${result}" ]]; then
+    echo "ERROR: ${app}: ${result} not found (pass --build to generate it)" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "==> ${app}: validating ${result}"
+
+  # Normalise: a kubenix build is either a List (.items) or a single object.
+  # `(.items // [.]) | .[]` yields each object; split_doc separates them into a
+  # multi-document YAML stream that kubeconform reads from stdin.
+  if ! yq -p=json -o=yaml '(.items // [.]) | .[] | split_doc' "${result}" >/tmp/nix-manifests.yaml 2>/tmp/nix-yq.err; then
+    echo "    failed to normalise ${result}:" >&2
+    sed 's/^/      /' /tmp/nix-yq.err >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if ! kubeconform \
+        -strict \
+        -summary \
+        -kubernetes-version "${KUBE_VERSION}" \
+        -schema-location default \
+        -schema-location "${CRD_SCHEMAS}" \
+        -ignore-missing-schemas \
+        /tmp/nix-manifests.yaml; then
+    echo "    kubeconform FAILED for ${app}" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  checked=$((checked + 1))
+done < <(discover_apps)
+
+echo
+if [[ ${failures} -gt 0 ]]; then
+  echo "Manifest validation FAILED: ${failures} app(s) with errors (${checked} passed)." >&2
+  exit 1
+fi
+
+echo "Manifest validation passed: ${checked} app(s) validated."


### PR DESCRIPTION
## Summary

Adds CI checks that schema-validate Kubernetes manifests on pull requests, so template/schema errors are caught before deploy instead of at `helm upgrade` / Argo CD sync time.

## What's included

| File | Purpose |
|---|---|
| `scripts/validate-helm.sh` | `helm lint` + `helm template` every path-type Helm app in `clusters/*/apps.yaml` (shared `server/` chart + per-app `values.yaml`), piped through `kubeconform`. |
| `scripts/validate-manifests.sh` | Builds each kubenix app (`applications/<app>/flake.nix`) and schema-checks the rendered `result.json` with `kubeconform`. |
| `.github/workflows/validate-manifests.yaml` | Runs both as parallel jobs on PRs to `master`. |
| `scripts/README-validation.md` | Usage, requirements, and local-run instructions. |

## Details

- Uses **kubeconform** against `KUBE_VERSION` (default `1.28.0`, matching the cluster).
- Custom resources are checked against the [CRDs-catalog](https://github.com/datreeio/CRDs-catalog); CRDs not in the catalog are skipped (`-ignore-missing-schemas`) rather than failing.
- `result.json` is gitignored, so the kubenix job runs `nix build` fresh (`--build`), mirroring the existing render workflow.
- Both scripts support filtering to specific apps and an overridable `KUBE_VERSION`.

## Testing

- Discovery, `helm lint`, and `helm template` verified locally for all Helm apps (11 validated).
- kubenix `result.json` normalisation verified for all 8 `flake.nix` apps.
- Full script flow exercised end-to-end with a `kubeconform` stub.
- `bash -n` and `shellcheck` clean.

## Notes

- `openclaw` has no committed `flake.nix`, so it is not auto-discovered by the kubenix validator (documented in the README).